### PR TITLE
CT-8 Use flask blueprints and add basic Charts.js implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.swp
+venv/
+gen/
 __pycache__/
 .idea/
-venv/
-
+.webassets-cache/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.swp
 __pycache__/
+.idea/
+venv/
+

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,19 +1,31 @@
-from flask import Flask, render_template
+from flask import Flask
+from flask_assets import Environment
+
+from .blueprints import index
+from .util import bundles
 
 
 def create_app(test_config=None):
-    # create and configure the app
     app = Flask(__name__, instance_relative_config=True)
 
-    if test_config is None:
-        # load the instance config, if it exists, when not testing
-        app.config.from_pyfile('config.py', silent=True)
-    else:
-        # load the test config if passed in
-        app.config.from_mapping(test_config)
-
-    @app.route('/')
-    def hello():
-        return render_template('index.html')
+    _load_config(app, test_config)
+    _load_blueprints(app)
+    _load_assets(app)
 
     return app
+
+
+def _load_config(app, test_config):
+    if test_config is None:
+        app.config.from_pyfile('config.py', silent=True)
+    else:
+        app.config.from_mapping(test_config)
+
+
+def _load_blueprints(app):
+    app.register_blueprint(index)
+
+
+def _load_assets(app):
+    assets = Environment(app)
+    assets.register(bundles)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,19 @@
+from flask import Flask, render_template
+
+
+def create_app(test_config=None):
+    # create and configure the app
+    app = Flask(__name__, instance_relative_config=True)
+
+    if test_config is None:
+        # load the instance config, if it exists, when not testing
+        app.config.from_pyfile('config.py', silent=True)
+    else:
+        # load the test config if passed in
+        app.config.from_mapping(test_config)
+
+    @app.route('/')
+    def hello():
+        return render_template('index.html')
+
+    return app

--- a/app/blueprints/__init__.py
+++ b/app/blueprints/__init__.py
@@ -1,0 +1,1 @@
+from .index import index

--- a/app/blueprints/index.py
+++ b/app/blueprints/index.py
@@ -1,0 +1,14 @@
+from flask import Blueprint, render_template, abort
+from jinja2 import TemplateNotFound
+
+
+index = Blueprint('index', __name__,
+                  template_folder='templates')
+
+
+@index.route('/')
+def show():
+    try:
+        return render_template('index.html')
+    except TemplateNotFound:
+        abort(404)

--- a/app/static/js/index.js
+++ b/app/static/js/index.js
@@ -1,0 +1,38 @@
+var ctx = document.getElementById('myChart').getContext('2d');
+var myChart = new Chart(ctx, {
+    type: 'bar',
+    data: {
+        labels: ['Red', 'Blue', 'Yellow', 'Green', 'Purple', 'Orange'],
+        datasets: [{
+            label: '# of Votes',
+            data: [12, 19, 3, 5, 2, 3],
+            backgroundColor: [
+                'rgba(255, 99, 132, 0.2)',
+                'rgba(54, 162, 235, 0.2)',
+                'rgba(255, 206, 86, 0.2)',
+                'rgba(75, 192, 192, 0.2)',
+                'rgba(153, 102, 255, 0.2)',
+                'rgba(255, 159, 64, 0.2)'
+            ],
+            borderColor: [
+                'rgba(255, 99, 132, 1)',
+                'rgba(54, 162, 235, 1)',
+                'rgba(255, 206, 86, 1)',
+                'rgba(75, 192, 192, 1)',
+                'rgba(153, 102, 255, 1)',
+                'rgba(255, 159, 64, 1)'
+            ],
+            borderWidth: 1
+        }]
+    },
+    options: {
+        scales: {
+            yAxes: [{
+                ticks: {
+                    beginAtZero: true
+                }
+            }]
+        },
+        responsive: false
+    }
+});

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,17 @@
+{# app/templates/index.html #}
+
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <!-- TO-DO: Replace with bundled asset file to reduce browser load -->
+        <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js"></script>
+    </head>
+    <body>
+        {% block body %}
+            <canvas id="myChart" width="400" height="400"></canvas>
+            {% assets "index_js" %}
+                <script type="text/javascript" src="{{ ASSET_URL }}"></script>
+            {% endassets %}
+        {% endblock %}
+    </body>
+</html>

--- a/app/util/__init__.py
+++ b/app/util/__init__.py
@@ -1,0 +1,1 @@
+from .assets import bundles

--- a/app/util/assets.py
+++ b/app/util/assets.py
@@ -1,0 +1,7 @@
+from flask_assets import Bundle
+
+bundles = {
+    'index_js': Bundle(
+        'js/index.js',
+        output='gen/index.js'),
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 click==7.1.2
 Flask==1.1.2
+Flask-Assets==2.0
 itsdangerous==1.1.0
 Jinja2==2.11.2
 MarkupSafe==1.1.1
+webassets==2.0
 Werkzeug==1.0.1


### PR DESCRIPTION
**Refactoring using flask blueprints**
Flask allows us to import our endpoints as [blueprints](https://flask.palletsprojects.com/en/1.1.x/blueprints/). We can use blueprints to separate our endpoint logic from our app initialization (\_\_init\_\_.py stuff), and just import them as we go.

**Embedding charts**
We can use [Chart.js](
https://www.chartjs.org/docs/latest/) to produce the charts for our dataset, and these changes include a simple bar chart as an example.

**Other references**
https://exploreflask.com/en/latest/static.html
https://benalexkeen.com/creating-graphs-using-flask-and-d3/